### PR TITLE
base58.js: directly bind to built object build/Release/base58.node

### DIFF
--- a/base58.js
+++ b/base58.js
@@ -1,4 +1,4 @@
-var lib = require('bindings')('base58');
+var lib = require('./build/Release/base58.node');
 var crypto = require('crypto');
 
 // Vanilla Base58 Encoding


### PR DESCRIPTION
This was required to work on Linux.  Followed BitcoinJS style for referencing the bindings, otherwise the tests would not work.
