### PR TITLE
Removes excessive multiply

### DIFF
--- a/base58.js
+++ b/base58.js
@@ -45,7 +45,6 @@ var base58 = {
     if(str.length == 0) return zerobuf;
     var answer = bignum(0);
     for(var i=0; i<str.length; i++) {
-    answer.mul(58)
       answer = answer.mul(58);
       answer = answer.add(ALPHABET_INV[str[i]]);
     };


### PR DESCRIPTION
This pull request removes an unnecessary multiply inside the inner `decode` loop.
In doing so, average run time for the tests is decreased by 50%.
