### PR TITLE
Remove bignum dependency, optimize byte operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,13 @@ base58
 
 An implementation of Base58 and Base58Check encodings for nodejs.  Note, the
 implementation of Base58Check differs slightly from that described on Wikipedia
-in that it does not prepend a version byte onto the data being encoded.  This
-implementation uses the bignum library (which is a native module and uses the
-openssl bignumber library functions).
+in that it does not prepend a version byte onto the data being encoded.
 
-NOTE: earlier versions of this package used native C code instead of bignum, but
+NOTE: Early versions of this package used native C code instead of bignum, but
 it was found to be unstable in a production environment (likely due to bugs in the
-C code).  This version uses bignum and appears to be very stable, but slower.  The
-C version of this package is still available on the "native-module" branch.  A few
-additional methods added to bignum would probably bring the speed of this version 
-on part with with C version.  
+C code). Recent versions used bignum for stability, but were slower. This version
+of the package uses a JavaScript algorithm adapted from digit-array with additional
+optimizations.
 
 Installation
 ============

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     {"name": "Stefan Thomas", "email": "moon@justmoon.net"},
     {"name": "Andrew Schaaf", "email": "andrew@andrewschaaf.com"},
     {"name": "Jeff Garzik", "email": "jgarzik@bitpay.com"},
-    {"name": "Stephen Pair", "email": "stephen@bitpay.com"}
+    {"name": "Stephen Pair", "email": "stephen@bitpay.com"},
+    {"name": "Jared Deckard", "email": "jared.deckard@gmail.com"}
   ], 
   "main": "./base58",
   "keywords": [
@@ -25,9 +26,6 @@
   },
   "scripts": {
     "test": "mocha"
-  },
-  "dependencies": {
-    "bignum": ">=0.6.1"
   },
   "devDependencies": {
     "mocha": ">1.0.0"


### PR DESCRIPTION
Remove `bignum` to make package lighter.
Optimize byte operations to make base58 encoding/decoding faster.

Benchmark with `bignum`:

```
load overhead: 10ms
encode: 16,018 ops/sec
decode: 21,472 ops/sec
```

Benchmark without `bignum`:

```
load overhead: 3ms
encode: 202,899 ops/sec
decode: 254,545 ops/sec
```

Similar changes just landed in https://github.com/cryptocoinjs/bs58/pull/6.
