### PR TITLE
Fix binary string comparison failure

### DIFF
--- a/base58.js
+++ b/base58.js
@@ -94,7 +94,7 @@ var base58Check = {
     var hash = doubleSHA256(data);
     var hash4 = hash.slice(0, 4);
 
-    if (csum.toString() != hash4.toString()) {
+    if (csum.toString('hex') != hash4.toString('hex')) {
       throw new Error("checksum mismatch");
     }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -14,7 +14,12 @@ var testData = [
   ["ecac89cad93923c02321", "EJDM8drfXA6uyA", "2W1Yd5Zu6WGyKVtHGMrH"],
   ["10c8511e", "Rt5zm", "3op3iuGMmhs"],
   ["00000000000000000000", "1111111111", "111111111146Momb"],
-  ["", "", "3QJmnh"]
+  ["", "", "3QJmnh"],
+  ["0062e907b15cbf27d5425399ebf6f0fb50ebb88f18", "12NvYg7CXwVYtMDYia7n9viekJ6d5", "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"]
+];
+
+var invalidTestData = [
+  "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNb"
 ];
 
 suite('basic');
@@ -45,5 +50,17 @@ test('allData', function() {
     base58.decodeTest(raw, b58);
     base58Check.encodeTest(raw, b58Check);
     base58Check.decodeTest(raw, b58Check);
+  });
+
+  base58Check.invalidDecodeTest = function(b58str) {
+    assert.throws(function(){
+        base58Check.decode(b58str);
+      },
+      /checksum mismatch/
+    );
+  };
+
+  invalidTestData.forEach(function(datum) {
+    base58Check.invalidDecodeTest(datum);
   });
 });


### PR DESCRIPTION
While replacing replacing [bitpay/bitcore](https://github.com/bitpay/bitcore/)'s base58 lib with `base58-native` as a dep, their tests failed due to this patch:
https://github.com/bitpay/bitcore/issues/402

It seems that comparing strings generated with `Buffer.toString()` will give false positives for some special characters. Their solution was to encode the bytes as hex before comparison.

``` js
new Buffer('94', 'hex').toString() == new Buffer('93', 'hex').toString()
true

new Buffer('94', 'hex').toString('hex') == new Buffer('93', 'hex').toString('hex')
false
```

Fixes #10.
